### PR TITLE
updated dynamoDB read/write usage metrics

### DIFF
--- a/config/templates.yml
+++ b/config/templates.yml
@@ -411,18 +411,18 @@ templates:
     DynamoDBReadUsage:
       AlarmActions: warn
       Namespace: AWS/DynamoDB
-      MetricName: ConsumedReadCapacityUnits
-      ComparisonOperator: GreaterThanThreshold
+      MetricName: ReadThrottleEvents
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       DimensionsName: TableName
       Statistic: Sum
-      Threshold: 80
+      Threshold: 1
       EvaluationPeriods: 2
     DynamoDBWriteUsage:
       AlarmActions: warn
       Namespace: AWS/DynamoDB
-      MetricName: ConsumedWriteCapacityUnits
-      ComparisonOperator: GreaterThanThreshold
+      MetricName: WriteThrottleEvents
+      ComparisonOperator: GreaterThanOrEqualToThreshold
       DimensionsName: TableName
       Statistic: Sum
-      Threshold: 80
+      Threshold: 1
       EvaluationPeriods: 2


### PR DESCRIPTION
Switched metrics from consumed capacity units to throttle events.
A threshold for consumed capacity units would depend on the allocated capacity of the table.
Using throttled events as a metric would indicate that all the capacity units have been consumed, but this may not indicate a problem as throttle events can and should be handled by applications