### PR TITLE
Add datapoints to alarm, allow use of ExtendedStatistic

### DIFF
--- a/lib/templates/alarms.rb
+++ b/lib/templates/alarms.rb
@@ -162,12 +162,13 @@ CloudFormation do
       Property('EvaluateLowSampleCountPercentile', params['EvaluateLowSampleCountPercentile']) unless params['EvaluateLowSampleCountPercentile'].nil?
       Property('EvaluationPeriods', FnFindInMap("#{alarmHash}",'EvaluationPeriods',Ref('EnvironmentType')))
       Property('ExtendedStatistic', params['ExtendedStatistic']) unless params['ExtendedStatistic'].nil?
+      Property('DatapointsToAlarm', params['DatapointsToAlarm']) unless params['DatapointsToAlarm'].nil?
       Property('InsufficientDataActions', insufficientDataActions)
       Property('MetricName', FnFindInMap("#{alarmHash}",'MetricName',Ref('EnvironmentType')))
       Property('Namespace', FnFindInMap("#{alarmHash}",'Namespace',Ref('EnvironmentType')))
       Property('OKActions', oKActions)
       Property('Period', FnFindInMap("#{alarmHash}",'Period',Ref('EnvironmentType')))
-      Property('Statistic', FnFindInMap("#{alarmHash}",'Statistic',Ref('EnvironmentType')))
+      Property('Statistic', FnFindInMap("#{alarmHash}",'Statistic',Ref('EnvironmentType'))) unless !params['ExtendedStatistic'].nil?
       Property('Threshold', FnFindInMap("#{alarmHash}",'Threshold',Ref('EnvironmentType')))
       Property('TreatMissingData',FnFindInMap("#{alarmHash}",'TreatMissingData',Ref('EnvironmentType')))
       Property('Unit', params['Unit']) unless params['Unit'].nil?


### PR DESCRIPTION
Added a check on the statistic parameter, to ensure it is not created if the ExtendedStatistic value is defined. You can't define both of these parameters and since statistic is the default in all of our templates, ExtendedStatistic is only chosen if it is added to a config as an override.