### PR TITLE
Change Lambda timeouts to be shorter.

### DIFF
--- a/lib/templates/master.rb
+++ b/lib/templates/master.rb
@@ -161,7 +161,7 @@ CloudFormation do
     Property('Handler', 'handler.main')
     Property('MemorySize', 128)
     Property('Runtime', 'python3.6')
-    Property('Timeout', 300)
+    Property('Timeout', 120)
     Property('Role', FnGetAtt('LambdaExecutionRole','Arn'))
   end
 
@@ -178,7 +178,7 @@ CloudFormation do
     Property('Handler', 'main')
     Property('MemorySize', 128)
     Property('Runtime', 'go1.x')
-    Property('Timeout', 300)
+    Property('Timeout', 30)
     Property('Role', FnGetAtt('LambdaExecutionRole','Arn'))
   end
 
@@ -195,7 +195,7 @@ CloudFormation do
     Property('Handler', 'main')
     Property('MemorySize', 128)
     Property('Runtime', 'go1.x')
-    Property('Timeout', 300)
+    Property('Timeout', 30)
     Property('Role', FnGetAtt('LambdaExecutionRole','Arn'))
   end
 
@@ -212,7 +212,7 @@ CloudFormation do
     Property('Handler', 'handler.run_check')
     Property('MemorySize', 128)
     Property('Runtime', 'python3.6')
-    Property('Timeout', 300)
+    Property('Timeout', 30)
     Property('Role', FnGetAtt('EcsCICheckLambdaExecutionRole','Arn'))
   end
 


### PR DESCRIPTION
We don't want to be billed unnecessarily long for certain checks, especially those that run every minute.