### PR TITLE
Bug fix for none action type when alarm action isn't set

### DIFF
--- a/lib/templates/alarms.rb
+++ b/lib/templates/alarms.rb
@@ -40,7 +40,7 @@ CloudFormation do
     warn: FnIf('WarnSNS',[ Ref('SnsTopicWarn') ], [ ]),
     task: FnIf('TaskSNS',[ Ref('SnsTopicTask') ], [ ]),
     info: FnIf('InfoSNS',[ Ref('SnsTopicInfo') ], [ ]),
-    none: nil,
+    none: [],
   }
 
   alarms.each do |alarm|
@@ -89,7 +89,7 @@ CloudFormation do
 
     if !params['InsufficientDataActions'].nil?
       insufficientDataActions = actionsEnabledMap[ params['InsufficientDataActions'].downcase.to_sym ]
-    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task || params['InsufficientDataAction'].downcase.to_sym == :none
+    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task
       insufficientDataActions = []
     elsif !params['AlarmActions'].nil?
       insufficientDataActions = actionsEnabledMap[ params['AlarmActions'].downcase.to_sym ]
@@ -99,7 +99,7 @@ CloudFormation do
 
     if !params['OKActions'].nil?
       oKActions = actionsEnabledMap[ params['OKActions'].downcase.to_sym ]
-    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task || params['OKActions'].downcase.to_sym == :none
+    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task
       oKActions = []
     elsif !params['AlarmActions'].nil?
       oKActions = actionsEnabledMap[ params['AlarmActions'].downcase.to_sym ]

--- a/lib/templates/alarms.rb
+++ b/lib/templates/alarms.rb
@@ -40,6 +40,7 @@ CloudFormation do
     warn: FnIf('WarnSNS',[ Ref('SnsTopicWarn') ], [ ]),
     task: FnIf('TaskSNS',[ Ref('SnsTopicTask') ], [ ]),
     info: FnIf('InfoSNS',[ Ref('SnsTopicInfo') ], [ ]),
+    none: nil,
   }
 
   alarms.each do |alarm|
@@ -160,7 +161,7 @@ CloudFormation do
       Condition "Condition#{alarmHash}" if conditions.length > 0
       Type('AWS::CloudWatch::Alarm')
       Property('ActionsEnabled', FnIf('MonitoringDisabled', false, FnFindInMap("#{alarmHash}",'ActionsEnabled',Ref('EnvironmentType'))))
-      Property('AlarmActions', alarmActions)
+      Property('AlarmActions', alarmActions) unless alarmActions.nil?
       Property('AlarmDescription', params['AlarmDescription'])
       Property('ComparisonOperator', FnFindInMap("#{alarmHash}",'ComparisonOperator',Ref('EnvironmentType')))
       Property('Dimensions', params['Dimensions'])
@@ -168,10 +169,10 @@ CloudFormation do
       Property('EvaluationPeriods', FnFindInMap("#{alarmHash}",'EvaluationPeriods',Ref('EnvironmentType')))
       Property('ExtendedStatistic', params['ExtendedStatistic']) unless params['ExtendedStatistic'].nil?
       Property('DatapointsToAlarm', params['DatapointsToAlarm']) unless params['DatapointsToAlarm'].nil?
-      Property('InsufficientDataActions', insufficientDataActions)
+      Property('InsufficientDataActions', insufficientDataActions) unless insufficientDataActions.nil?
       Property('MetricName', FnFindInMap("#{alarmHash}",'MetricName',Ref('EnvironmentType')))
       Property('Namespace', FnFindInMap("#{alarmHash}",'Namespace',Ref('EnvironmentType')))
-      Property('OKActions', oKActions)
+      Property('OKActions', oKActions) unless oKActions.nil?
       Property('Period', FnFindInMap("#{alarmHash}",'Period',Ref('EnvironmentType')))
       Property('Statistic', FnFindInMap("#{alarmHash}",'Statistic',Ref('EnvironmentType'))) unless !params['ExtendedStatistic'].nil?
       Property('Threshold', FnFindInMap("#{alarmHash}",'Threshold',Ref('EnvironmentType')))

--- a/lib/templates/alarms.rb
+++ b/lib/templates/alarms.rb
@@ -89,7 +89,7 @@ CloudFormation do
 
     if !params['InsufficientDataActions'].nil?
       insufficientDataActions = actionsEnabledMap[ params['InsufficientDataActions'].downcase.to_sym ]
-    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task
+    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task || params['InsufficientDataAction'].downcase.to_sym == :none
       insufficientDataActions = []
     elsif !params['AlarmActions'].nil?
       insufficientDataActions = actionsEnabledMap[ params['AlarmActions'].downcase.to_sym ]
@@ -99,7 +99,7 @@ CloudFormation do
 
     if !params['OKActions'].nil?
       oKActions = actionsEnabledMap[ params['OKActions'].downcase.to_sym ]
-    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task
+    elsif !params['AlarmActions'].nil? && params['AlarmActions'].downcase.to_sym == :task || params['OKActions'].downcase.to_sym == :none
       oKActions = []
     elsif !params['AlarmActions'].nil?
       oKActions = actionsEnabledMap[ params['AlarmActions'].downcase.to_sym ]
@@ -161,7 +161,7 @@ CloudFormation do
       Condition "Condition#{alarmHash}" if conditions.length > 0
       Type('AWS::CloudWatch::Alarm')
       Property('ActionsEnabled', FnIf('MonitoringDisabled', false, FnFindInMap("#{alarmHash}",'ActionsEnabled',Ref('EnvironmentType'))))
-      Property('AlarmActions', alarmActions) unless alarmActions.nil?
+      Property('AlarmActions', alarmActions)
       Property('AlarmDescription', params['AlarmDescription'])
       Property('ComparisonOperator', FnFindInMap("#{alarmHash}",'ComparisonOperator',Ref('EnvironmentType')))
       Property('Dimensions', params['Dimensions'])
@@ -169,10 +169,10 @@ CloudFormation do
       Property('EvaluationPeriods', FnFindInMap("#{alarmHash}",'EvaluationPeriods',Ref('EnvironmentType')))
       Property('ExtendedStatistic', params['ExtendedStatistic']) unless params['ExtendedStatistic'].nil?
       Property('DatapointsToAlarm', params['DatapointsToAlarm']) unless params['DatapointsToAlarm'].nil?
-      Property('InsufficientDataActions', insufficientDataActions) unless insufficientDataActions.nil?
+      Property('InsufficientDataActions', insufficientDataActions)
       Property('MetricName', FnFindInMap("#{alarmHash}",'MetricName',Ref('EnvironmentType')))
       Property('Namespace', FnFindInMap("#{alarmHash}",'Namespace',Ref('EnvironmentType')))
-      Property('OKActions', oKActions) unless oKActions.nil?
+      Property('OKActions', oKActions)
       Property('Period', FnFindInMap("#{alarmHash}",'Period',Ref('EnvironmentType')))
       Property('Statistic', FnFindInMap("#{alarmHash}",'Statistic',Ref('EnvironmentType'))) unless !params['ExtendedStatistic'].nil?
       Property('Threshold', FnFindInMap("#{alarmHash}",'Threshold',Ref('EnvironmentType')))


### PR DESCRIPTION
Simplified the way the none action type is defined. Having it set to an empty array rather than nil allows you to have no additional logic. It also fixes a bug @rererecursive found when generating with the none action type while an AlarmAction is not set.