### PR TITLE
Add elasticache current connections alarms

### DIFF
--- a/lib/config/templates.yml
+++ b/lib/config/templates.yml
@@ -459,6 +459,24 @@ templates:
       Statistic: Minimum
       Threshold: 75
       EvaluationPeriods: 10
+    CurrentConnectionsTask:
+      AlarmActions: task
+      Namespace: AWS/ElastiCache
+      MetricName: CurrConnections
+      ComparisonOperator: GreaterThanThreshold
+      DimensionsName: CacheClusterId
+      Statistic: Maximum
+      Threshold: 50000
+      EvaluationPeriods: 10
+    CurrentConnectionsCrit:
+      AlarmActions: crit
+      Namespace: AWS/ElastiCache
+      MetricName: CurrConnections
+      ComparisonOperator: GreaterThanThreshold
+      DimensionsName: CacheClusterId
+      Statistic: Maximum
+      Threshold: 60000
+      EvaluationPeriods: 10
   ElasticFileSystem: # AWS::EFS::FileSystem
     PercentIOLimitHigh:
       AlarmActions: crit


### PR DESCRIPTION
Created this for Tallie where the thresholds were suggested, not sure what we should have for the defaults but this is a start. I have deployed the task alarm for Tallie and it was successful, hence this PR. Let me know if any changes need to be made