### PR TITLE
Add AuroraInstance template

### DIFF
--- a/lib/config/templates.yml
+++ b/lib/config/templates.yml
@@ -338,6 +338,34 @@ templates:
       Statistic: Minimum
       Threshold: 75
       EvaluationPeriods: 60
+  AuroraInstance:
+    DBConnections:
+      AlarmActions: crit
+      Namespace: AWS/RDS
+      MetricName: DatabaseConnections
+      ComparisonOperator: GreaterThanThreshold
+      DimensionsName: DBInstanceIdentifier
+      Statistic: Minimum
+      Threshold: 750    # This needs to be customised for whichever instance type is being used as it is not a percentage and they all differ
+      EvaluationPeriods: 10
+    CPUUtilizationHighSpike:
+      AlarmActions: crit
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      DimensionsName: DBInstanceIdentifier
+      Statistic: Minimum
+      Threshold: 95
+      EvaluationPeriods: 10
+    CPUUtilizationHighBase:
+      AlarmActions: warn
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      ComparisonOperator: GreaterThanThreshold
+      DimensionsName: DBInstanceIdentifier
+      Statistic: Minimum
+      Threshold: 75
+      EvaluationPeriods: 60
   DBCluster: # AWS::RDS::DBCluster
     CPUUtilizationHighSpike:
       AlarmActions: crit

--- a/lib/config/templates.yml
+++ b/lib/config/templates.yml
@@ -346,7 +346,7 @@ templates:
       ComparisonOperator: GreaterThanThreshold
       DimensionsName: DBInstanceIdentifier
       Statistic: Minimum
-      Threshold: 750    # This needs to be customised for whichever instance type is being used as it is not a percentage and they all differ
+      Threshold: 45    # This needs to be customised for whichever instance type is being used as it is not a percentage and they all differ
       EvaluationPeriods: 10
     CPUUtilizationHighSpike:
       AlarmActions: crit


### PR DESCRIPTION
The comment "This needs to be customised for whichever instance type is being used as it is not a percentage and they all differ" is important, I don't know what to put for the default. I left it as what I set it for TileFive, which was 750/100 --> 75% for a db.r3.large. Most of the mid-range instances have max connections at 1000, so maybe this is the best compromise (http://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Managing.Performance.html#AuroraMySQL.Managing.MaxConnections)