### PR TITLE
update ApiGateway Latency template: add TreatMissingData: notBreachin…

### DIFF
--- a/lib/config/templates.yml
+++ b/lib/config/templates.yml
@@ -548,6 +548,7 @@ templates:
       Statistic: Average
       Threshold: 1000
       EvaluationPeriods: 2
+      TreatMissingData: notBreaching
   DynamoDBTable: #AWS::DynamoDB::Table
     DynamoDBReadUsage:
       AlarmActions: warn


### PR DESCRIPTION
…g because insufficient data just means the api isn't being hit often