### PR TITLE
Updated gemspec to limit cfndsl to 0.17.1

### DIFF
--- a/cfn_monitor.gemspec
+++ b/cfn_monitor.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "thor", "~> 0.19"
-  spec.add_dependency "cfndsl", "~> 0.16"
+  spec.add_dependency "cfndsl", "~> 0.16", "<0.17.1"
   spec.add_dependency "aws-sdk-cloudformation", "~> 1", "<2"
   spec.add_dependency "aws-sdk-s3", "~> 1", "<2"
   spec.add_dependency "aws-sdk-elasticloadbalancingv2", "~> 1", "<2"


### PR DESCRIPTION
Anything above ~0.17.1 gives this error when running `cfn_monitor generate`:

```
/usr/local/bundle/gems/cfndsl-0.17.5/lib/cfndsl.rb:63:in `eval_file_with_extras': undefined local variable or method `resources' for CfnDsl:Module (NameError)
```

I know we've moved away from cfn-monitor (and therefore I haven't done any more investigation as to what _causes_ this) but it would still be nice to fix this, because it catches me out every time lol.